### PR TITLE
Build for arm64 (but disable for now)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,6 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/amd64,linux/arm64/v8
+        platforms: linux/amd64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,6 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64/v8
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM docker.io/library/debian:sid AS builder
 RUN ln -fs /bin/bash /bin/sh
 WORKDIR "/"
 RUN apt-get update && apt-get -y install curl git gcc g++ musl musl-dev musl-tools mold
+RUN ln -s /usr/bin/$(uname -m)-linux-gnu-ar /bin/$(uname -m)-linux-musl-ar
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > ri.sh && chmod +x ri.sh && ./ri.sh -y
-RUN source "$HOME/.cargo/env" && rustup target add x86_64-unknown-linux-musl
+RUN source "$HOME/.cargo/env" && rustup target add $(uname -m)-unknown-linux-musl
 COPY build.sh /build.sh
 RUN /build.sh https://github.com/nuta/nsh
 COPY ripgrep-no-jemalloc.diff /ripgrep-no-jemalloc.diff

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ docker run --rm -it rust-userland
 
 - Add more common tools, specially those that are not in coreutils but are expected to usually exist, e.g., `ps`, `sed`, `gzip`, `diff`, `less`, `find`, `ip` (and others from iproute2), `mount` (and others from util-linux), `curl`, `wget`, … (maybe wrappers around `procs`/`sd`/`fd` could help)
 - Add more new tools written in Rust that provide similar/valuable functionality but aren't a drop-in (some already included)
-- Build for arm64 (currently the Dockerfile has the x86 target hardcoded)
 - Try compilation with [relibc](https://gitlab.redox-os.org/redox-os/relibc) or [mustang](https://github.com/sunfishcode/mustang) instead of musl
 - Check if the extracted userland also works with [Kerla](https://github.com/nuta/kerla) instead of Linux
 

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,8 @@ if [ "$PATCH" != "" ]; then
   git apply "$PATCH"
 fi
 source "$HOME/.cargo/env"
-RUSTFLAGS="-C target-feature=+crt-static" mold -run cargo build --target x86_64-unknown-linux-musl --release "$@"
+# aarch64-unknown-linux-musl or x86_64-unknown-linux-musl
+RUSTFLAGS="-C target-feature=+crt-static" mold -run cargo build --target $(uname -m)-unknown-linux-musl --release "$@"
 mkdir -p /rust-bin
-strip target/x86_64-unknown-linux-musl/release/"$BIN"
-mv target/x86_64-unknown-linux-musl/release/"$BIN" /rust-bin/
+strip target/$(uname -m)-unknown-linux-musl/release/"$BIN"
+mv target/$(uname -m)-unknown-linux-musl/release/"$BIN" /rust-bin/


### PR DESCRIPTION
This should build a multiarch container image.
ARCH-linux-musl-ar is not provided by musl-dev but maybe it's enough to
call ARCH-linux-gnu-ar directly through a symlink.

Disable arm64 build for now because the frawk crate has a compilation error.