### PR TITLE
Explicitly cross-compile and don't use binary translation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,6 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64/v8
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,11 @@ if [ "$PATCH" != "" ]; then
 fi
 source "$HOME/.cargo/env"
 # aarch64-unknown-linux-musl or x86_64-unknown-linux-musl
-RUSTFLAGS="-C target-feature=+crt-static -C strip=symbols" mold -run cargo build --target $(uname -m)-unknown-linux-musl --release "$@"
+if [ "$(cat /uname-m)" = "x86_64" ]; then
+  LINK="mold -run"
+else
+  LINK=""
+fi
+RUSTFLAGS="-C target-feature=+crt-static -C strip=symbols" $LINK cargo build --target $(cat /uname-m)-unknown-linux-musl --release "$@"
 mkdir -p /rust-bin
-mv target/$(uname -m)-unknown-linux-musl/release/"$BIN" /rust-bin/
+mv target/$(cat /uname-m)-unknown-linux-musl/release/"$BIN" /rust-bin/


### PR DESCRIPTION
  Assuming that the GitHub Action runners are on amd64 and that
    cross-compilation works, we don't need to compile in the container
    through binary translation of the compiler itself.

This temporarily enabled the arm64 image build but only for testing.